### PR TITLE
fix RootAccountLoginsFilter, fixes #32

### DIFF
--- a/templates/cis-benchmark.template
+++ b/templates/cis-benchmark.template
@@ -1990,9 +1990,9 @@ Resources:
       LogGroupName: !GetAtt ResourceForGetCloudWatchLogName.LogName
       FilterPattern: |-
         {
-          ($.userIdentity.type = "Root") &&
-          ($.userIdentity.invokedBy NOT EXISTS) &&
-          ($.eventType != "AwsServiceEvent")
+          $.userIdentity.type = "Root" &&
+          $.userIdentity.invokedBy NOT EXISTS &&
+          $.eventType != "AwsServiceEvent"
         }
       MetricTransformations:
       - MetricValue: '1'


### PR DESCRIPTION
*Issue #, if available:*
#32 

*Description of changes:*
Remove the parenthesis from the RootAccountLoginFilter filter pattern.

This is functionally the same filter, but it will also be recognized as compliant by AWS Security Hub.r

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
