### PR TITLE
Update 1.22 benchmark rule to handle actions as string or array

### DIFF
--- a/templates/cis-benchmark.template
+++ b/templates/cis-benchmark.template
@@ -1038,7 +1038,7 @@ Resources:
     - ResourceForEvaluateCISBenchmarkPreconditions
     Properties:
       FunctionName: CIS-EvaluateFullAdminPolicyPermissions
-      Description: Evaluates whether policies allowing full admin privileges '*:*'
+      Description: Evaluates whether policies allowing full admin privileges '*'
         have been created
       Code:
         ZipFile: |
@@ -1056,7 +1056,7 @@ Resources:
               VersionId = policy['DefaultVersionId']
             )
             # search for full admin privileges within the policy statements
-            if jmespath.search('PolicyVersion.Document.Statement[?Effect == \'Allow\' && contains(Resource, \'*\') && contains (Action, \'*\')]', policy_version):
+            if jmespath.search('PolicyVersion.Document.Statement[?Effect == \'Allow\' && contains(Resource, \'*\') && contains (to_array(Action), \'*\')]', policy_version):
               return_value = 'NON_COMPLIANT'
             return return_value
           def lambda_handler(event, context):
@@ -1095,7 +1095,7 @@ Resources:
     - ResourceForEvaluateCISBenchmarkPreconditions
     Properties:
       ConfigRuleName: CIS-EvaluateFullAdminPrivilegesPolicies
-      Description: CIS 1.22 - Ensure IAM policies that allow full '*:*' administrative
+      Description: CIS 1.22 - Ensure IAM policies that allow full '*' administrative
         privileges are not created (Scored)
       Scope:
         ComplianceResourceTypes:


### PR DESCRIPTION
The current JMESpath is providing inconsistent compliance alerts for config rule monitoring item 1.22 in the benchmark.

The current check is:

```python
jmespath.search('PolicyVersion.Document.Statement[?Effect == \'Allow\' && contains(Resource, \'*\') && contains (Action, \'*\')]', policy_version)
```

But the issue is that contains work different if its a 'string' or if its an 'array'

So this action will be marked as noncompliant, because it found a "*" in the string.

```
Action: "dynamodb:*"
```

But this action wont be marked non compliant, beacuse when its an array, it looks for a single item being "*"

```
Action: ["ec2:DescribeInstances", "dynamodb:Describe*"]
```

The fix is just to convert the action to_arrary, so it always operates on array and checks for any item to be "*"

http://jmespath.org/specification.html#contains

```
If $subject is an array, this function returns true if one of the elements in the array is equal to the provided $search value.

If the provided $subject is a string, this function returns true if the string contains the provided $search argument.
```

http://jmespath.org/specification.html#to-array

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
